### PR TITLE
Disassembly filename and constants file changes

### DIFF
--- a/hydra/commands/constants.py
+++ b/hydra/commands/constants.py
@@ -14,3 +14,5 @@ BENCHMARKS = ['WatermanBenchmark', 'fir_filter', 'aha_mont64', 'crc32',
                 'sglib_combined', 'slre', 'st', 'statemate', 'ud', 'wikisort']
 
 SUPPORTED_TOOLCHAINS = ['arm', 'rvgcc', 'armgcc']
+
+ARM_ROOT = "Your ARM root path here"

--- a/hydra/commands/disassemble.py
+++ b/hydra/commands/disassemble.py
@@ -51,7 +51,7 @@ class Disassemble(Base):
         # Compile with makefile and optimization flags
         os.system('make -f makefile CC={} "CFLAGS={}" {}'.format(cc, '', command))
         artifact = '{}_{}.a'.format(os.path.basename(benchmark_path), toolchain)
-        assembly_file = '{}_{}_disassembly'.format(os.path.basename(benchmark_path), toolchain)
+        assembly_file = '{}_{}_disassembly.txt'.format(os.path.basename(benchmark_path), toolchain)
 
         # Ensure build artifact generated with makefile execution is valid
         self.check_file_valid(os.path.abspath(artifact))

--- a/hydra/commands/utils.py
+++ b/hydra/commands/utils.py
@@ -22,7 +22,7 @@ Authors: Jennifer Hellar
 import os
 import sys
 
-from .constants import BENCHMARKS
+from .constants import BENCHMARKS, ARM_ROOT
 
 def get_cc_objdump_optflags(benchmark_name, toolchain):
         """
@@ -222,7 +222,7 @@ def write_sub_makefiles(benchmark_name, file_name, toolchain):
 
     with open(file_name, 'w+') as makefile:
         if toolchain == 'arm':
-            makefile.write('ARM_ROOT=/home/jlh24/arm/developmentstudio-2020.1-1/sw/ARMCompiler5.06u7/\n\n')
+            makefile.write('ARM_ROOT=' + ARM_ROOT + '\n\n')
 
         makefile.write('CC = ' + cc + '\n')
         makefile.write('override CFLAGS += ' + ccflags + '\n')


### PR DESCRIPTION
**Overview**
A small pr to update the disassembly filename and move ARM_ROOT into the constants file.

**Features**
- Pull the ARM_ROOT definition into the constants file for easier setup
- Update the *_disassembly filename to *_disassembly.txt

**Note**
Could be useful to have a base path constant for the arm compiler directory in the setup script. Then you would only have to change one path and the rest could be updated relative to that (would have to find workaround for getting the correct version).